### PR TITLE
Execute all data migrations at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ Output:
 +--------------------------+------------------------+--------+
 ```
 
+Or use the `--all` option to migrate an entire namespace at once:
+
+```terminal
+php artisan data-migration:migrate App\\DataMigrations --all
+```
+
 Or with `DataMigration` facade:
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ],
     "require": {
       "php": ">=7.0.0",
-      "laravel/framework": "^5.5"
+      "laravel/framework": "^5.5",
+      "haydenpierce/class-finder": "^0.3.2"
     },
     "autoload": {
       "psr-4": {

--- a/src/Console/DataMigrationMigrateCommand.php
+++ b/src/Console/DataMigrationMigrateCommand.php
@@ -29,7 +29,17 @@ class DataMigrationMigrateCommand extends DataMigrationCommand
      */
     public function handle()
     {
-        $this->setMigration($this->argument('migration'));
+        $this->runMigration($this->argument('migration'));
+    }
+
+    /**
+     * Runs a data migration
+     *
+     * @param string $migration which migration to run
+     */
+    protected function runMigration(string $migration)
+    {
+        $this->setMigration($migration);
 
         $this->getOutput()->writeln(sprintf('<comment>Calculating migrate to %s:</comment>', $this->getMigration()->model()));
         $progressBar = $this->output->createProgressBar(count($this->getMigration()->data()));


### PR DESCRIPTION
Closes #1.

This PR adds the ability to execute an entire namespace worth of data migrations at once.

To use this, pass a namespace as the `migration` argument, along with the `--all` option. Existing behavior (passing a migration class name alone) in unchanged.

This adds a dependancy to haydenpierce/class-finder ([package](https://packagist.org/packages/haydenpierce/class-finder) | [source](https://gitlab.com/hpierce1102/ClassFinder)), in order to detect and list classes inside the user-provided namespace.

Feel free to let me know of what you think of this implementation